### PR TITLE
Wholesome cors coverage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,9 @@ services:
   #    RDS_HOST: postgis
   #  links:
   #    - postgis
-  semantic-workshop:
-    image: radius314/bmlt-semantic-workshop:1.3.2
-    ports:
-      - "8001:80"
-    links:
-      - tomato-web
+  #semantic-workshop:
+  #  image: bmlt-enabled/bmlt-semantic-workshop:1.3.2
+  #  ports:
+  #    - "8001:80"
+  #  links:
+  #    - tomato-web

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,3 @@ services:
   #    RDS_HOST: postgis
   #  links:
   #    - postgis
-  #semantic-workshop:
-  #  image: bmlt-enabled/bmlt-semantic-workshop:1.3.2
-  #  ports:
-  #    - "8001:80"
-  #  links:
-  #    - tomato-web

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 certifi==2018.11.29
 chardet==3.0.4
-Django==2.1.5
-django-cors-headers==2.4.0
+Django==2.2.1
 django-filter==2.1.0
 djangorestframework==3.9.1
 idna==2.8
@@ -11,4 +10,4 @@ psycopg2-binary==2.7.6.1
 pytz==2018.9
 requests==2.21.0
 six==1.12.0
-urllib3==1.24.1
+urllib3==1.25.3

--- a/src/tomato/middleware.py
+++ b/src/tomato/middleware.py
@@ -1,0 +1,10 @@
+class CorsMiddleware(object):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        response["Access-Control-Allow-Origin"] = "*"
+        response['Access-Control-Allow-Methods'] = 'POST, GET, OPTIONS, PUT'
+
+        return response

--- a/src/tomato/settings/__init__.py
+++ b/src/tomato/settings/__init__.py
@@ -39,16 +39,15 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.postgres',
     'django.contrib.gis',
-    'corsheaders',
     'rest_framework',
     'django_filters',
     'tomato.api',
 ]
 
 MIDDLEWARE = [
+    'tomato.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',


### PR DESCRIPTION
I spent some time trying to dig into the internals of the `format=json` response formatter.  The middleware installed via pip was not respecting those endpoints.  Rather than dig further into a 3rd party library to determine what exactly was going on, I wrote my own middleware and reduced tomato by one dependency.