### PR TITLE
Work around django-filters, django-cache-machine, and django-redis interaction

### DIFF
--- a/src/tomato/api/viewsets.py
+++ b/src/tomato/api/viewsets.py
@@ -36,5 +36,5 @@ class MeetingViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.Meeting.objects.filter(deleted=False, published=True).order_by('pk')
     serializer_class = serializers.MeetingSerializer
     pagination_class = StandardResultsSetPagination
-    filter_fields = ('id', 'root_server', 'source_id', 'weekday', 'start_time', 'duration', 'formats',
+    filter_fields = ('id', 'root_server', 'source_id', 'weekday', 'start_time', 'duration',
                      'language', 'latitude', 'longitude', 'published', 'deleted',)


### PR DESCRIPTION
We use the `django-cache-machine` `CachingManager` as the manager for the Format model, and it in turn uses its `CachingQuerySet`. We also use `django-filters` to get query filtering with `djangorestframework`.

It was resulting in this stack trace when pulling up the list of `meetings`.

```
Internal Server Error: /rest/v1/meetings/
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.6/dist-packages/django/core/handlers/base.py", line 145, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python3.6/dist-packages/django/core/handlers/base.py", line 143, in _get_response
    response = response.render()
  File "/usr/local/lib/python3.6/dist-packages/django/template/response.py", line 106, in render
    self.content = self.rendered_content
  File "/usr/local/lib/python3.6/dist-packages/rest_framework/response.py", line 72, in rendered_content
    ret = renderer.render(self.data, accepted_media_type, context)
  File "/usr/local/lib/python3.6/dist-packages/rest_framework/renderers.py", line 733, in render
    context = self.get_context(data, accepted_media_type, renderer_context)
  File "/usr/local/lib/python3.6/dist-packages/rest_framework/renderers.py", line 710, in get_context
    'filter_form': self.get_filter_form(data, view, request),
  File "/usr/local/lib/python3.6/dist-packages/rest_framework/renderers.py", line 642, in get_filter_form
    html = backend().to_html(request, queryset, view)
  File "/usr/local/lib/python3.6/dist-packages/django_filters/rest_framework/backends.py", line 105, in to_html
    return template.render(context, request)
  File "/usr/local/lib/python3.6/dist-packages/django/template/backends/django.py", line 61, in render
    return self.template.render(context)
  File "/usr/local/lib/python3.6/dist-packages/django/template/base.py", line 171, in render
    return self._render(context)
  File "/usr/local/lib/python3.6/dist-packages/django/template/base.py", line 163, in _render
    return self.nodelist.render(context)
  File "/usr/local/lib/python3.6/dist-packages/django/template/base.py", line 937, in render
    bit = node.render_annotated(context)
  File "/usr/local/lib/python3.6/dist-packages/django/template/base.py", line 904, in render_annotated
    return self.render(context)
  File "/usr/local/lib/python3.6/dist-packages/django/template/base.py", line 987, in render
    output = self.filter_expression.resolve(context)
  File "/usr/local/lib/python3.6/dist-packages/django/template/base.py", line 671, in resolve
    obj = self.var.resolve(context)
  File "/usr/local/lib/python3.6/dist-packages/django/template/base.py", line 796, in resolve
    value = self._resolve_lookup(context)
  File "/usr/local/lib/python3.6/dist-packages/django/template/base.py", line 858, in _resolve_lookup
    current = current()
  File "/usr/local/lib/python3.6/dist-packages/django/forms/forms.py", line 304, in as_p
    errors_on_separate_row=True,
  File "/usr/local/lib/python3.6/dist-packages/django/forms/forms.py", line 243, in _html_output
    'field_name': bf.html_name,
  File "/usr/local/lib/python3.6/dist-packages/django/utils/html.py", line 388, in <lambda>
    klass.__str__ = lambda self: mark_safe(klass_str(self))
  File "/usr/local/lib/python3.6/dist-packages/django/forms/boundfield.py", line 33, in __str__
    return self.as_widget()
  File "/usr/local/lib/python3.6/dist-packages/django/forms/boundfield.py", line 93, in as_widget
    renderer=self.form.renderer,
  File "/usr/local/lib/python3.6/dist-packages/django/forms/widgets.py", line 241, in render
    context = self.get_context(name, value, attrs)
  File "/usr/local/lib/python3.6/dist-packages/django/forms/widgets.py", line 678, in get_context
    context = super().get_context(name, value, attrs)
  File "/usr/local/lib/python3.6/dist-packages/django/forms/widgets.py", line 639, in get_context
    context['widget']['optgroups'] = self.optgroups(name, context['widget']['value'], attrs)
  File "/usr/local/lib/python3.6/dist-packages/django/forms/widgets.py", line 587, in optgroups
    for index, (option_value, option_label) in enumerate(self.choices):
  File "/usr/local/lib/python3.6/dist-packages/django_filters/fields.py", line 252, in __iter__
    for value in iterable:
  File "/usr/local/lib/python3.6/dist-packages/django/forms/models.py", line 1137, in __iter__
    for obj in queryset:
  File "/usr/local/lib/python3.6/dist-packages/caching/base.py", line 144, in __iter__
    self.cache_objects(to_cache, query_key)
  File "/usr/local/lib/python3.6/dist-packages/caching/base.py", line 100, in cache_objects
    cache.add(query_key, objects, timeout=self.timeout)
  File "/usr/local/lib/python3.6/dist-packages/django_redis/cache.py", line 27, in _decorator
    return method(self, *args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/django_redis/cache.py", line 84, in add
    return self.client.add(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/django_redis/client/default.py", line 206, in add
    return self.set(key, value, timeout, version=version, client=client, nx=True)
  File "/usr/local/lib/python3.6/dist-packages/django_redis/client/default.py", line 142, in set
    timeout = int(timeout * 1000)
TypeError: unsupported operand type(s) for *: 'object' and 'int'
```

The root cause is that instaces of the `CachingQuerySet` class have a `timeout` member, and it is always set to `DEFAULT_TIMEOUT` (https://github.com/django-cache-machine/django-cache-machine/blob/6bf54be3600a0191c6890fe07d864da8c3824b33/caching/base.py#L153). The value of `DEFAULT_TIMEOUT` is an object instance, allowing the library to use object identity for comparison (https://github.com/django/django/blob/8093aaa8ff9dd7386a069c6eb49fcc1c5980c033/django/core/cache/backends/base.py#L23).

This all seems like a reasonable approach. The problem is when `django_filters` does a deep copy of the CachingQuerySet object (https://github.com/carltongibson/django-filter/blob/master/django_filters/filterset.py#L201). Because it is a deep copy, the timeout member of the CachingQuerySet instance is no longer the same as `DEFAULT_TIMEOUT`. This causes downstream comparisons to fail.

The problematic downstream comparison is in `django_redis` (https://github.com/jazzband/django-redis/blob/879cbc270466a2d731f369e7cfede375705a0fc5/django_redis/client/default.py#L127). Because `timeout` is no longer `DEFAULT_TIMEOUT`, the `timeout = self._backend.default_timeout` line of code does not get hit. This causes a line to get hit that tries to multiply `timeout` (an object) by `1000` (an integer) (https://github.com/jazzband/django-redis/blob/879cbc270466a2d731f369e7cfede375705a0fc5/django_redis/client/default.py#L141).