### PR TITLE
chore: Update Wisconsin root server (id 119)

### DIFF
--- a/rootServerList.json
+++ b/rootServerList.json
@@ -11,7 +11,7 @@
 {"id":"113","name":"NA Ireland","rootURL":"https://bmlt.nasouth.ie/main_server/"},
 {"id":"116","name":"NA Hawai'i","rootURL":"https://na-hawaii.org/bmltmain/"},
 {"id":"117","name":"San Jose Area","rootURL":"https://www.sjna.org/main_server/"},
-{"id":"119","name":"Wisconsin Region","rootURL":"https://bmlt.wi-na.org/main_server/"},
+{"id":"119","name":"Wisconsin Region","rootURL":"https://bmlt.wisconsinna.org/main_server/"},
 {"id":"120","name":"NA New Jersey","rootURL":"https://bmlt.nanj.org/main_server/"},
 {"id":"121","name":"Connecticut Region","rootURL":"https://bmlt.ctna.org/"},
 {"id":"122","name":"Volunteer Region","rootURL":"https://natennessee.org/main_server/"},


### PR DESCRIPTION
Change to https://bmlt.wisconsinna.org/main_server/